### PR TITLE
Fix compatibility with new Core interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ a drop-in replacement of the `ocamlp4` extension.
 
 ## Usage
 
-    $ opam pin add ppx_bitstring . -n
-    $ opam install ppx_bitstring --verbose
+    $ opam pin add -k git ppx_bitstring https://github.com/xguerin/ppx_bitstring
     $ ocamlfind ocamlopt -linkpkg -thread -package core,bitstring,ppx_bitstring.match main.ml -o main.native
 
 ## Syntax

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ a drop-in replacement of the `ocamlp4` extension.
 
     $ opam pin add ppx_bitstring . -n
     $ opam install ppx_bitstring --verbose
+    $ ocamlfind ocamlopt -linkpkg -thread -package core,bitstring,ppx_bitstring.match main.ml -o main.native
 
 ## Syntax
 

--- a/ppx_bitstring_match.ml
+++ b/ppx_bitstring_match.ml
@@ -266,7 +266,7 @@ let rec evaluate_expr = function
 (* Parsing fields *)
 
 let parse_fields ~loc str =
-  let e = List.fold_right ~init:[] ~f:(fun e acc -> [Bytes.trim e] @ acc) (String.split ~on:':' str) in
+  let e = List.fold_right ~init:[] ~f:(fun e acc -> [StdLabels.Bytes.trim e] @ acc) (String.split ~on:':' str) in
   match e with
   | [ "_" as pat ] ->
       (parse_pattern ~loc pat, None, None)


### PR DESCRIPTION
`Core.Std` gained a new module named [`Bytes`](https://github.com/janestreet/core_kernel/blob/master/src/core_bytes.mli) which does not export `Bytes.trim`. Compiling `ppx_bitstring` thus results in the error attached bellow.

- This pull request forces the use of the `Bytes` module of the OCaml standard library, fixing the compilation error.
- It also adds an example to the readme on how to compile a program that uses this library, as I had a hard time discovering the library was named `ppx_bitstring.match`.
- The installation instructions were edited to use git as a backend. In this way opam will automatically track the git repository.


The compilation error:
```
[NOTE] Package ppx_bitstring is already pinned to https://github.com/xguerin/ppx_bitstring. This will reset metadata.
Proceed ? [Y/n]
[ppx_bitstring] Fetching https://github.com/xguerin/ppx_bitstring
Initialized empty Git repository in /home/henri/.opam/no-ssl/packages.dev/ppx_bitstring/.git/
[master (root-commit) 39feaf9] opam-git-init
warning: no common commits
From https://github.com/xguerin/ppx_bitstring
 * [new ref]                    -> opam-ref
.gitignore
.merlin
LICENSE
META
Makefile
README.md
opam
ppx_bitstring_match.ml
samples/Base
samples/Ext3
samples/GIF
samples/GIF.ml
samples/Header
samples/IPv4
samples/simple.ml
samples/simple.pa.ml
HEAD is now at 64a187b Updated README
Installing new package description for ppx_bitstring from https://github.com/xguerin/ppx_bitstring/opam
 
ppx_bitstring needs to be installed.
The following actions will be performed:
 - install   ppx_bitstring.0.1*
=== 1 to install ===
Do you want to continue ? [Y/n]
=-=- Synchronizing package archives -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[ppx_bitstring] Fetching https://github.com/xguerin/ppx_bitstring
HEAD is now at 64a187b Updated README
 
=-=- Installing packages =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
Building ppx_bitstring.0.1:
  make
  make PREFIX=/home/henri/.opam/no-ssl install
ocamlfind ocamlopt -package compiler-libs.common,bitstring,core,ppx_tools.metaquot -linkpkg -thread -o ppx_bitstring.match ppx_bitstring_match.ml
findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/henri/.opam/no-ssl/lib/ocaml/compiler-libs, /home/henri/.opam/no-ssl/lib/ocaml
File "ppx_bitstring_match.ml", line 269, characters 53-63:
Error: Unbound value Bytes.trim
make: *** [all] Error 2
Makefile:2: recipe for target 'all' failed
[ERROR] The compilation of ppx_bitstring.0.1 failed.
Removing ppx_bitstring.0.1.
```