### PR TITLE
Prevent using absolute paths

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-COMPILER = $(HOME)/.opam/system/bin/ocamlfind ocamlopt
+COMPILER = ocamlfind ocamlopt
 FLAGS    = -package compiler-libs.common,bitstring,core,ppx_tools.metaquot -linkpkg -thread 
 SOURCES	 = ppx_bitstring.ml
 TARGET	 = ppx_bitstring.ext


### PR DESCRIPTION
Some systems do not have $(HOME)/.opam/system/bin/ocamlfind. Use $PATH to get ocamlfind