### PR TITLE
Implement support for length (-1) for bitstring and string fields in constructor expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ match%bitstring bs with
 | {| _ |} -> (* Do something else *)
 ```
 
-Usage example with the `let` PPX extension:
+Usage example with the PPX extension for constructing bitstrings:
 
 ```ocaml
-let%bitstring bs = {|
+let my_bitstring =
+  [%bitstring {|
     1 : 1;
     a : 2;
     b : 16 : bigendian;
@@ -64,4 +65,3 @@ Copyright (c) 2016 Xavier R. Guérin <copyright@applepine.org>
 Permission to use, copy, modify, and distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,6 +3,7 @@ all:
 	ocamlfind opt -package bitstring,core -thread -linkpkg  -ppx ../src/ppx_bitstring.ext constructor.ml -o constructor
 	ocamlfind opt -package bitstring,core -thread -linkpkg  -ppx ../src/ppx_bitstring.ext ext3.ml -o ext3
 	ocamlfind opt -package bitstring,core -thread -linkpkg  -ppx ../src/ppx_bitstring.ext net.ml -o net
+	ocamlfind opt -package bitstring,core -thread -linkpkg  -ppx ../src/ppx_bitstring.ext bitstring_in_bitstring.ml -o bitstring_in_bitstring
 
 clean:
-	rm -f *.cm* *.o gif constructor ext3 net
+	rm -f *.cm* *.o gif constructor ext3 net bitstring_in_bitstring

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,6 +4,7 @@ all:
 	ocamlfind opt -package bitstring,core -thread -linkpkg  -ppx ../src/ppx_bitstring.ext ext3.ml -o ext3
 	ocamlfind opt -package bitstring,core -thread -linkpkg  -ppx ../src/ppx_bitstring.ext net.ml -o net
 	ocamlfind opt -package bitstring,core -thread -linkpkg  -ppx ../src/ppx_bitstring.ext bitstring_in_bitstring.ml -o bitstring_in_bitstring
+	ocamlfind opt -package bitstring,core -thread -linkpkg  -ppx ../src/ppx_bitstring.ext swap.ml -o swap
 
 clean:
 	rm -f *.cm* *.o gif constructor ext3 net bitstring_in_bitstring

--- a/tests/bitstring_in_bitstring.ml
+++ b/tests/bitstring_in_bitstring.ml
@@ -6,17 +6,15 @@ let version  = 0x42
 let data     = 10
 
 let () =
-  let header = let%bitstring header = {| version : 8 |} in header in
+  let header = [%bitstring {| version : 8 |}] in
   let bits =
-    let%bitstring bits =
+    [%bitstring
       {| magic  : -1 : string
        ; header : -1 : bitstring
        ; data   :  8
-       |}
-    in
-    bits
+       |}]
   in
   Bitstring.hexdump_bitstring stdout bits;
-  let bits2 = let%bitstring bits2 = {| magic : -1 : string |} in bits2 in
+  let bits2 = [%bitstring {| magic : -1 : string |}] in
   Bitstring.hexdump_bitstring stdout bits2
 ;;

--- a/tests/bitstring_in_bitstring.ml
+++ b/tests/bitstring_in_bitstring.ml
@@ -1,0 +1,22 @@
+open Bitstring
+open Printf
+
+let magic    = "\xde\xad\xbe\xef"
+let version  = 0x42
+let data     = 10
+
+let () =
+  let header = let%bitstring header = {| version : 8 |} in header in
+  let bits =
+    let%bitstring bits =
+      {| magic  : -1 : string
+       ; header : -1 : bitstring
+       ; data   :  8
+       |}
+    in
+    bits
+  in
+  Bitstring.hexdump_bitstring stdout bits;
+  let bits2 = let%bitstring bits2 = {| magic : -1 : string |} in bits2 in
+  Bitstring.hexdump_bitstring stdout bits2
+;;

--- a/tests/constructor.ml
+++ b/tests/constructor.ml
@@ -1,11 +1,20 @@
 open Bitstring
 open Printf
 
-let _ =
-  let version = 1 in
-  let data = 10 in
-  let%bitstring bits = {|
-    version : 4;
-    data : 12
-  |} in
-  Bitstring.hexdump_bitstring stdout bits
+let a = 0x23
+let b = 0x42
+
+let print_input () =
+  let%bitstring a = {| a : 8 |}
+  and b = {| b : 8 |}
+  in
+  Bitstring.hexdump_bitstring stdout a;
+  Bitstring.hexdump_bitstring stdout b;
+;;
+
+let () =
+  print_input ();
+  let bits1 = [%bitstring {| a : 8 |}] in
+  let%bitstring bits2 = {| b : 16 |} in
+  Bitstring.hexdump_bitstring stdout bits1;
+  Bitstring.hexdump_bitstring stdout bits2

--- a/tests/net.ml
+++ b/tests/net.ml
@@ -2,15 +2,15 @@ open Bitstring
 open Printf
 
 let buildUDP src dst len chk =
-  let%bitstring udp = {|
+  [%bitstring {|
     src : 16 : bigendian;
     dst : 16 : bigendian;
     len : 16 : bigendian;
     chk : 16 : bigendian
-  |} in udp
+  |}]
 
 let buildIP ihl len proto chk (s0, s1, s2, s3) (d0, d1, d2, d3) pld =
-  let%bitstring ipv4 = {|
+  [%bitstring {|
     4     : 4;
     ihl   : 4;
     0     : 6; (* dscp *)
@@ -25,7 +25,7 @@ let buildIP ihl len proto chk (s0, s1, s2, s3) (d0, d1, d2, d3) pld =
     s0    : 8; s1    : 8; s2    : 8; s3    : 8;
     d0    : 8; d1    : 8; d2    : 8; d3    : 8;
     pld   : (len - ihl * 4) * 8 : bitstring
-  |} in ipv4
+  |}]
 
 let () =
   let udp = buildUDP 0x1000 0x1000 0 0 in
@@ -52,4 +52,3 @@ let () =
       Printf.printf "Decoding passed\n"
   | {| _ |} ->
     Printf.printf "Decoding failed\n"
-

--- a/tests/swap.ml
+++ b/tests/swap.ml
@@ -1,0 +1,18 @@
+open Bitstring
+open Printf
+
+let swap bs =
+  match%bitstring bs with
+  | {| a : 1 : bitstring; b : 1 : bitstring|} ->
+     [%bitstring {| b : 1 : bitstring; a : 1 : bitstring |}]
+  | {| _ |} -> failwith "invalid input"
+
+let one   = [%bitstring {| 1 : 2 |}]
+let two   = [%bitstring {| 2 : 2 |}]
+let three = [%bitstring {| 3 : 2 |}]
+
+let () =
+  assert(Bitstring.equals two (swap one));
+  assert(Bitstring.equals one (swap two));
+  assert(Bitstring.equals three (swap three));
+  printf "PASSED\n"


### PR DESCRIPTION
This adds support for the special value `-1` as the length of bitstring and string fields in constructor expressions.
Support for this is present in the bitstring camlp4 syntax.
It should resolve #14.

It also allows using extension points inside a `match%bitstring` expression. This should resolve #12, see `tests/swap.ml`.

Further, I changed the constructor style to from
```ocaml
let%bitstring foo = {| 0x42 : 8 |} in
```
to
```ocaml
let foo = [%bitstring {| 0x42 |} : 8 in
```