### PR TITLE
Use [=] instead of [==] for comparison of size

### DIFF
--- a/src/ppx_bitstring.ml
+++ b/src/ppx_bitstring.ml
@@ -646,11 +646,11 @@ let gen_assignment_behavior loc sym fields =
     | Some (v) ->
       let vexpr = Ast_convenience.int v in
       [%expr let _res = [%e rep] in
-             if (Bitstring.bitstring_length _res) == [%e vexpr]
+             if (Bitstring.bitstring_length _res) = [%e vexpr]
              then _res else raise Exit]
     | None ->
       [%expr let _res = [%e rep] in
-             if (Bitstring.bitstring_length _res) == [%e size]
+             if (Bitstring.bitstring_length _res) = [%e size]
              then _res else raise Exit]
   in
   let exprs = List.fold_right


### PR DESCRIPTION
Change the comparison operator used when asserting that a created bitstring has the intended size to `=` instead of `==`.
Since the type being compared is `int`, testing for physical equality doesn't seem useful.

Further, using `==` is deprecated when using https://github.com/janestreet/core, thus usages of `[%bitstring]` or `let%bitstring` will generate a deprecation warning.