### PR TITLE
keep guards in pattern matching

### DIFF
--- a/src/ppx_bitstring.ml
+++ b/src/ppx_bitstring.ml
@@ -897,8 +897,13 @@ let gen_case cur nxt res case =
   let loc = case.pc_lhs.ppat_loc in
   match case.pc_lhs.ppat_desc with
   | Ppat_constant (Pconst_string (value, _)) ->
-    let beh = [%expr [%e res.exp] := Some ([%e case.pc_rhs]); raise Exit][@metaloc loc]
-    in split_string ~on:';' value
+    let beh = [%expr [%e res.exp] := Some ([%e case.pc_rhs]); raise Exit][@metaloc loc] in
+    let beh =
+      match case.pc_guard with
+      | None -> beh
+      | Some cond -> [%expr if [%e cond] then [%e beh] else ()][@metaloc loc]
+    in
+    split_string ~on:';' value
     |> split_loc ~loc
     |> List.map ~f:parse_match_fields
     |> check_for_open_endedness

--- a/tests/BitstringParserTest.ml
+++ b/tests/BitstringParserTest.ml
@@ -195,15 +195,28 @@ let function_parser_inline_test context =
     assert_bool "Invlaid bitstring" false
 
 (*
+ * parser with a guard (PR#16)
+ *)
+
+let parser_with_guard_test context =
+  let bits = Bitstring.bitstring_of_string "abc" in
+  match%bitstring bits with
+  | {| "abc" : 24 : string |} when false ->
+    assert_bool "Guard was ignored" false
+  | {| _ |} ->
+    assert_bool "Guard was honored" true
+
+(*
  * Test suite definition
  *)
 
 let suite = "BitstringParserTest" >::: [
-    "ext3"            >:: ext3_test;
-    "gif"             >:: gif_test;
-    "pcap"            >:: pcap_test;
-    "function"        >:: function_parser_test;
-    "function_inline" >:: function_parser_inline_test
+    "ext3"              >:: ext3_test;
+    "gif"               >:: gif_test;
+    "pcap"              >:: pcap_test;
+    "function"          >:: function_parser_test;
+    "function_inline"   >:: function_parser_inline_test;
+    "parser_with_guard" >:: parser_with_guard_test
   ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
It seems that ppx\_bitstring drops guards in pattern matching. This patch restores it